### PR TITLE
Ensembl compatibility, Random seed set for background sampling 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ optional arguments:
                         choose to run PEKA on a specific region only, to specify multiple regions enter them space separated [DEFAULT None]
   -sub [SUBSAMPLE], --subsample [SUBSAMPLE]
                         if the crosslinks file is large, they can be subsampled to reduce runtime, can be True/False, recommended is True [DEFAULT True]
+  -seed [SET_SEEDS], --set_seeds [SET_SEEDS]
+                      If you want to ensure reproducibility of results the flag --set_seeds must be set to True.
+                      Can be True or False [DEFAULT True]. Note that setting seeds reduces the randomness of background sampling.
 ```
 
 **Common issues**

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ usage: peka.py [-h] -i INPUTPEAKS -x INPUTXLSITES -g GENOMEFASTA -gi GENOMEINDEX
 
 Search for enriched motifs around thresholded crosslinks in CLIP data.
 
+**IMPORTANT NOTE!** Make sure all the required inputs, i.e. bed files, genome in fasta format, genome index and regions file, follow the same naming convention for chromosome names. Either all files must use the UCSC (GENCODE) naming convention, which prefixes chromosome names with "chr" ("chr1", ..., "chrM") or all files should use Ensembl naming convention ("1", ..., "MT").
+
 required arguments:
   -i INPUTPEAKS, --inputpeaks INPUTPEAKS
                         CLIP peaks (intervals of crosslinks) in BED file format

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ optional arguments:
 **Common issues**
 
 If you have one of the following errors, it is because the numpy/pandas versions you are running are incompatible with PEKA.
-To ensure you are using the correct versions, we reccomend using our conda environment.
+To ensure you are using the correct versions, we recommend using our conda environment.
 ```
 AttributeError: type object 'object' has no attribute 'dtype'
 ```
@@ -98,7 +98,7 @@ or
 ```
 TypeError: sum() got an unexpected keyword argument 'axis'
 ```
-The script needs writing permission in the staging directory to save results and make an environment variable `TMPDIR` for temporary files. 
+The script needs writing permission in the staging directory to save results and make an environment variable `TMPDIR` for temporary files.
 If you get `KeyError: 'TMPDIR'` a solution would be to type `export TMPDIR=<path_to_folder>` in terminal where you want to run the script.
 
 **Outputs**

--- a/peka.py
+++ b/peka.py
@@ -1116,8 +1116,11 @@ def run(peak_file,
         # occurences for each kmer on relevant positions and add them to a list
         # for calculation of averages and standard deviations
         random_roxn = []
-        for _ in range(100):
+        for i in range(100):
+            # For reproducibility it is necessary to set a seed, but each instance gets it's own seed.
+            random.seed(i)
             random_seqs = random.sample(reference_sequences, len(sites))
+            # print("Random state in roxn sampling:", random.getstate())
             random_kmer_pos_count_t = pos_count_kmer(random_seqs, kmer_length, window, repeats=repeats)
             random_kmer_pos_count = {key.replace("T", "U"): value for key, value in random_kmer_pos_count_t.items()}
             if repeats == "masked" or repeats == "repeats_only":

--- a/peka.py
+++ b/peka.py
@@ -270,7 +270,7 @@ def get_regions_map(regions_file):
     df_cds_utr_ncrna.to_csv("{}/cds_utr_ncrna_regions.bed".format(TEMP_PATH), **to_csv_kwrgs)
 
 
-def remove_chr(df_in, chr_sizes, chr_name="chrM"):
+def remove_chr(df_in, chr_sizes, chr_name=["chrM", "MT"]):
     """Remove chromosomes that are not in genome annotations.
 
     Also removes ``chr_name`` from DataFrame.
@@ -279,7 +279,7 @@ def remove_chr(df_in, chr_sizes, chr_name="chrM"):
         chr_sizes, names=["chrom", "end"], sep="\t", header=None, dtype={"chrom": str, "end": int}
     )
     df_in = df_in[df_in["chrom"].isin(df_chr_sizes["chrom"].values)]
-    return df_in[~(df_in["chrom"] == chr_name)]
+    return df_in[~(df_in["chrom"].isin(chr_name))]
 
 
 def intersect(interval_file, s_file):

--- a/peka.py
+++ b/peka.py
@@ -144,6 +144,9 @@ def cli():
                         required=False, help='choose to run PEKA on a specific region only, to specify multiple regions enter them space separated [DEFAULT None]')
     optional.add_argument('-sub',"--subsample", dest='subsample', default='True', type=lambda x:bool(strtobool(x)),
                         help='if the crosslinks file is very large, they can be subsampled to reduce runtime, can be True/False [DEFAULT True]')
+    optional.add_argument('-seed',"--set_seeds", dest='set_seeds', default='True', type=lambda x:bool(strtobool(x)),
+                        help='If you want to ensure reproducibility of results the option set_seeds must be set to True. Can be True or False [DEFAULT True]. \n \
+                        Note that setting seeds reduces the randomness of background sampling.')
 
     parser._action_groups.append(optional)
     args = parser.parse_args()
@@ -165,7 +168,8 @@ def cli():
         args.repeats,
         args.alloutputs,
         args.specificregion,
-        args.subsample)
+        args.subsample,
+        args.set_seeds)
 
 
 # overriding pybedtools to_dataframe method to avoid warning
@@ -938,7 +942,8 @@ def run(peak_file,
     repeats,
     all_outputs,
     regions,
-    subsample
+    subsample,
+    set_seeds
 ):
     """Start the analysis.
 
@@ -1118,7 +1123,8 @@ def run(peak_file,
         random_roxn = []
         for i in range(100):
             # For reproducibility it is necessary to set a seed, but each instance gets it's own seed.
-            random.seed(i)
+            if set_seeds:
+                random.seed(i)
             random_seqs = random.sample(reference_sequences, len(sites))
             # print("Random state in roxn sampling:", random.getstate())
             random_kmer_pos_count_t = pos_count_kmer(random_seqs, kmer_length, window, repeats=repeats)
@@ -1304,6 +1310,7 @@ def main():
         all_outputs,
         regions,
         subsample,
+        set_seeds
     ) = cli()
 
     run(
@@ -1324,6 +1331,7 @@ def main():
         all_outputs,
         regions,
         subsample,
+        set_seeds
     )
 
 if __name__ == '__main__':


### PR DESCRIPTION
Ensembl compatibility: remove_chr function now also removes entries with chromosome annotated as "MT", not only "chrM".

--set_seeds flag was added to enable reproducible sampling of background RoXn. It is set to True by default.