### PR TITLE
Determination of relevant positions, Bugfixes for working with soft-masked genome, other minor fixes

### DIFF
--- a/peka.py
+++ b/peka.py
@@ -1201,13 +1201,15 @@ def run(peak_file,
             P_kmer_at_pos = (1 - ((n_possible_kmers - 1) / (n_possible_kmers)) ** (ntxn))
             P_kmer_at_pos = round(P_kmer_at_pos * 100, 2)
             print('Probability (%) that k-mer was found at position in sampled roxn (rounded to 2 decimal points):', P_kmer_at_pos)
-            if int(P_kmer_at_pos) == 100:
-                # Maximal threshold is 99 %, 100% threshold would result in no positions assigned to k-mers
-                P_kmer_at_pos = 99
+            if int(P_kmer_at_pos) > 90:
+                # Maximal threshold is 90 %, 100% threshold would result in no positions assigned to k-mers
+                # P_kmer_at_pos = 99
+                P_kmer_at_pos = 90
             else:
                 P_kmer_at_pos = int(P_kmer_at_pos)
 
-            relaxThreshold = int(P_kmer_at_pos / 10) * 10
+            # Threshold is relaxed by another 10 %
+            relaxThreshold = (P_kmer_at_pos - 10) if (P_kmer_at_pos - 10) > 0 else 0
 
             print('strict prtxn threshold:', P_kmer_at_pos)
             print('relaxed prtxn threshold:', relaxThreshold)

--- a/peka.py
+++ b/peka.py
@@ -126,27 +126,38 @@ def cli():
     optional.add_argument('-t',"--topn", type=int, default=20, nargs='?',
                         help='number of kmers ranked by z-score in descending order for clustering and plotting [DEFAULT 20]')
     optional.add_argument('-p',"--percentile", type=float, default=0.7, nargs='?',
-                        help='percentile for considering thresholded crosslinks eg. percentile 0.7 means \n \
-                            that a cDNA count threshold is determined at which >=70 percent of the crosslink sites within the region \n \
-                            have a cDNA count equal or below the threshold. Thresholded crosslinks have cDNA count above the threshold [DEFAULT 0.7]')
+                        help="""
+                        percentile for considering thresholded crosslinks eg. percentile 0.7 means
+                        that a cDNA count threshold is determined at which >=70 percent of the crosslink
+                        sites within the region have a cDNA count equal or below the threshold.
+                        Thresholded crosslinks have cDNA count above the threshold [DEFAULT 0.7]
+                        """)
     optional.add_argument('-c',"--clusters", type=int, default=5, nargs='?',
                         help='how many enriched kmers to cluster and plot [DEFAULT 5]')
     optional.add_argument('-s',"--smoothing", type=int, default=6, nargs='?',
                         help='window used for smoothing kmer positional distribution curves [DEFAULT 6]')
     optional.add_argument('-re',"--repeats", type=str, choices=['remove_repeats', 'masked', 'unmasked', 'repeats_only'], default='unmasked', nargs='?',
-                        help='how to treat repeating regions within genome (options: "masked", "unmasked", \n \
-                            "repeats_only", "remove_repeats"). When applying any of the options with the exception of \n \
-                                repeats == "unmasked", a genome with soft-masked repeat sequences should be \n \
-                                    used for input, ie. repeats in lowercase letters.')
+                        help="""
+                        how to treat repeating regions within genome (options: "masked", "unmasked", "repeats_only", "remove_repeats").
+                        When applying any of the options with the exception of repeats == "unmasked", a genome with soft-masked
+                        repeat sequences should be used for input, ie. repeats in lowercase letters.
+                        """)
     optional.add_argument('-a',"--alloutputs", dest='alloutputs', default='False', type=lambda x:bool(strtobool(x)),
                         help='controls the number of outputs, can be True or False [DEFAULT False]')
     optional.add_argument('-sr',"--specificregion", choices=["genome", "whole_gene", "intron", "UTR3", "other_exon", "ncRNA", "intergenic"], default=None, nargs='+',
-                        required=False, help='choose to run PEKA on a specific region only, to specify multiple regions enter them space separated [DEFAULT None]')
+                        required=False, help="""
+                        choose to run PEKA on a specific region only, to specify multiple regions enter them space separated [DEFAULT None]
+                        """)
     optional.add_argument('-sub',"--subsample", dest='subsample', default='True', type=lambda x:bool(strtobool(x)),
-                        help='if the crosslinks file is very large, they can be subsampled to reduce runtime, can be True/False [DEFAULT True]')
+                        help="""
+                        if the crosslinks file is very large, they can be subsampled to reduce runtime, can be True/False [DEFAULT True]
+                        """)
     optional.add_argument('-seed',"--set_seeds", dest='set_seeds', default='True', type=lambda x:bool(strtobool(x)),
-                        help='If you want to ensure reproducibility of results the option set_seeds must be set to True. Can be True or False [DEFAULT True]. \n \
-                        Note that setting seeds reduces the randomness of background sampling.')
+                        help="""
+                        If you want to ensure reproducibility of results the option set_seeds must be set to True.
+                        Can be True or False [DEFAULT True].
+                        Note that setting seeds reduces the randomness of background sampling.
+                        """)
 
     parser._action_groups.append(optional)
     args = parser.parse_args()
@@ -1266,7 +1277,7 @@ def run(peak_file,
         cluster_rename = get_clusters_name(clusters_dict)
         cluster_columns_rename = {c_id: (cluster_rename[c_id], list(clusters_dict[c_id])) for c_id in cluster_rename}
         df_cluster_sum.rename(columns=cluster_columns_rename).to_csv(f"{output_path}/{sum_name}", sep="\t")
-        # finnaly plot all the clusters and the wider window (-150 to 100) plot
+        # finally plot all the clusters and the wider window (-150 to 100) plot
         # with average occurences
         plot_positional_distribution(
             df_smooth, df_cluster_sum, clusters_dict, clusters_rank, sample_name, cluster_rename, region, kmer_length, output_path

--- a/peka.py
+++ b/peka.py
@@ -837,6 +837,7 @@ def get_clusters_name(c_dict):
     """
     c_con_dict = {}
     for cluster_id, kmers_list in c_dict.items():
+        kmers_list = [k.upper() for k in kmers_list]
         if len(kmers_list) == 1:
             # if there is only one kmer in a cluster than cluster name is kmer
             c_con_dict[cluster_id] = kmers_list[0]
@@ -1080,7 +1081,7 @@ def run(peak_file,
         print(f"Kmer positional counting runtime: {((time.time() - get_sequences_cp) / 60):.2f} min")
         kmer_pos_count = {key.replace("T", "U"): value for key, value in kmer_pos_count_t.items()}
         if repeats == "masked" or repeats == "repeats_only":
-            kmer_pos_count = {key.replace("t", "u"): value for key, value in kmer_pos_count_t.items()}
+            kmer_pos_count = {key.replace("t", "u").replace("T", "U"): value for key, value in kmer_pos_count_t.items()}
         # get position where the kmer count is maximal
         max_p = get_max_pos(kmer_pos_count, window_peak_l=15, window_peak_r=15)
         # prepare dataframe for outfile
@@ -1107,7 +1108,7 @@ def run(peak_file,
         print(f"Reference positional counts runtime: {((time.time() - rtxn_cp) / 60):.2f} min")
         ref_pc = {key.replace("T", "U"): value for key, value in ref_pc_t.items()}
         if repeats == "masked" or repeats == "repeats_only":
-            ref_pc = {key.replace("t", "u"): value for key, value in ref_pc_t.items()}
+            ref_pc = {key.replace("t", "u").replace("T", "U"): value for key, value in ref_pc_t.items()}
         # occurences of kmers on each position around all crosslinks not in
         # peaks (reference) relative to distal occurences
         roxn = {x: {} for x in ref_pc}
@@ -1133,7 +1134,7 @@ def run(peak_file,
             random_kmer_pos_count = {key.replace("T", "U"): value for key, value in random_kmer_pos_count_t.items()}
             if repeats == "masked" or repeats == "repeats_only":
                 random_kmer_pos_count = {
-                    key.replace("t", "u"): value for key, value in random_kmer_pos_count_t.items()
+                    key.replace("t", "u").replace("T", "U"): value for key, value in random_kmer_pos_count_t.items()
                 }
             roxn_sample = {x: {} for x in random_kmer_pos_count}
             for motif, pos_m in random_kmer_pos_count.items():

--- a/peka.py
+++ b/peka.py
@@ -1062,6 +1062,7 @@ def run(peak_file,
         )
         if repeats == "unmasked":
             sequences = [s.upper() for s in sequences]
+            reference_sequences = [s.upper() for s in reference_sequences]
         get_sequences_cp = time.time()
         # get positional counts for all kmers around thresholded crosslinks
         kmer_pos_count_t = pos_count_kmer(sequences, kmer_length, window_distal, repeats=repeats)

--- a/peka.py
+++ b/peka.py
@@ -1241,13 +1241,6 @@ def run(peak_file,
         print('prtxn confidence:', prtxn_conf)
 
         threshold = {pos: np.percentile(values, prtxn_conf, axis=0) for pos, values in temp_combined_roxn.items()}
-        import json
-        print('saving files')
-        with open(f"{output_path}/thresholds.txt", "w") as fp:
-            json.dump(threshold, fp)
-
-        with open(f"{output_path}/pos_roxn.txt", "w") as fp:
-            json.dump(temp_combined_roxn, fp)
 
         prtxn = {x: [] for x in rtxn}
         for kmer, posm in rtxn.items():

--- a/peka.py
+++ b/peka.py
@@ -1310,8 +1310,9 @@ def run(peak_file,
         df_out = pd.merge(df_out, df_z_score, left_index=True, right_index=True, how="outer")
         # using z-score we can also calculate p-values for each motif which are
         # then added to outfile table
-        zscoresFromPEKAscore = scipy.stats.zscore(df_out['PEKA-score'], axis=0, ddof=0, nan_policy='omit')
-        df_out["p-value"] = scipy.special.ndtr(-zscoresFromPEKAscore)
+        scoreDistribution = df_out.loc[df_out["PEKA-score"].notna(), 'PEKA-score']
+        zscoresFromPEKAscore = scipy.stats.zscore(scoreDistribution, axis=0, ddof=0)
+        df_out.loc[scoreDistribution.index.tolist(), "p-value"] = scipy.special.ndtr(-zscoresFromPEKAscore)
         # kmer positional occurences around thresholded crosslinks on positions
         # around -50 to 50 are also added to outfile table which is then finally
         # written to file

--- a/peka.py
+++ b/peka.py
@@ -1161,10 +1161,7 @@ def run(peak_file,
                         prtxn[kmer].append(pos)
                 except KeyError:
                     pass
-        # Assigns the max_p to kmers with empty prtxn list
-        for i, val in prtxn.items():
-            if len(val) == 0:
-                val.append(max_p[i])
+        # Leave an empty list for prtxn if none of the positions passed the relevant positions threshold
         random_aroxn = []
         for roxn_sample in random_roxn:
             aroxn_sample = {

--- a/peka.py
+++ b/peka.py
@@ -547,19 +547,6 @@ def pos_count_kmer(seqs, k_length, window, repeats, kmer_list=False):
     return kmer_pos_count
 
 
-def normalise_kmer_frequency(observed, reference):
-    """Normalize kmer counts - divide observed with reference counts."""
-    normalised = {}
-    for kmer, count in observed.items():
-        # In short regions of the reference there could be 0 of certain kmers.
-        # In such case, just normalize with 1.
-        try:
-            normalised[kmer] = count / reference[kmer] * 10 ** 6
-        except ZeroDivisionError:
-            normalised[kmer] = count * 10 ** 6
-    return normalised
-
-
 def get_max_pos(pos_count, window_peak_l=15, window_peak_r=15):
     """Return position with max values for every kmer in the dictionary."""
     max_pos = {}

--- a/peka.py
+++ b/peka.py
@@ -1309,11 +1309,9 @@ def run(peak_file,
                     z_score[key] = (artxn[key] - value) / random_std[key]
                 except KeyError:
                     # If there is no artxn entry for a given k-mer (due to absence of prtxn), then no PEKA-score is assigned.
-                    print('Not found in foreground:', key)
                     z_score[key] = np.nan
                 except FloatingPointError:
                     # In case of division by zero, no PEKA-score is assigned.
-                    print('Not found in background:', key)
                     z_score[key] = np.nan
         df_z_score = pd.DataFrame.from_dict(z_score, orient="index", columns=["PEKA-score"])
         df_out = pd.merge(df_out, df_z_score, left_index=True, right_index=True, how="outer")

--- a/peka.py
+++ b/peka.py
@@ -916,11 +916,11 @@ def plot_positional_distribution(df_in, df_sum, c_dict, c_rank, name, cluster_re
     sns.lineplot(data=df_ordered, ax=axs[axs_x_sumplt, axs_y_sumplt], ci=None, **lineplot_kwrgs)
     fig.savefig(f"{output_path}/{name}_{kmer_length}mer_{region}.pdf", format="pdf")
 
-def run(peak_file, 
-    sites_file, 
-    genome, 
-    genome_fai, 
-    regions_file, 
+def run(peak_file,
+    sites_file,
+    genome,
+    genome_fai,
+    regions_file,
     kmer_length,
     output_path,
     window,
@@ -958,8 +958,8 @@ def run(peak_file,
     - all_outputs: controls the amount of outputs produced in the analysis
     - subsample: whether or not to subsample crosslinks
     - repeats: how to treat repeating regions within genome
-    (options: 'masked', 'unmasked', 'repeats_only'). When applying 
-    any of the options with the exception of repeats == 'unmasked', a genome with masked 
+    (options: 'masked', 'unmasked', 'repeats_only'). When applying
+    any of the options with the exception of repeats == 'unmasked', a genome with masked
     repeat sequences should be used for input.
     """
     start = time.time()
@@ -977,22 +977,22 @@ def run(peak_file,
         "cds_utr_ncrna": "{}/cds_utr_ncrna_regions.bed".format(TEMP_PATH),
     }
     # Save run parameters into file
-    df_params = pd.Series(data={"peak_file": peak_file, 
-                            "sites_file": sites_file, 
-                            "regions": regions, 
-                            "kmer_length": kmer_length, 
-                            "genome": genome, 
-                            "genome_index_file": genome_fai, 
+    df_params = pd.Series(data={"peak_file": peak_file,
+                            "sites_file": sites_file,
+                            "regions": regions,
+                            "kmer_length": kmer_length,
+                            "genome": genome,
+                            "genome_index_file": genome_fai,
                             "gtf_segmentation_file": regions_file,
-                            "smoothing": smoothing, 
-                            "percentile": percentile, 
-                            "window": window, 
-                            "window_distal": window_distal, 
-                            "n_top_motifs": top_n, 
-                            "n_clusters": clusters, 
-                            "repeats" : repeats, 
-                            "subsample": subsample, 
-                            "all_outputs": all_outputs, 
+                            "smoothing": smoothing,
+                            "percentile": percentile,
+                            "window": window,
+                            "window_distal": window_distal,
+                            "n_top_motifs": top_n,
+                            "n_clusters": clusters,
+                            "repeats" : repeats,
+                            "subsample": subsample,
+                            "all_outputs": all_outputs,
                             })
 
     df_params.to_csv(f'{output_path}/{sample_name}_run_parameters.tsv', sep='\t', header=False)
@@ -1037,7 +1037,7 @@ def run(peak_file,
             sites.saveas(f'{output_path}/{sample_name}_thresholded_sites_{region}.bed.gz')
         # only continue analysis for region with over 100 thresholded sites
         if len(sites) < 100:
-            print(f"less then 100 thresholded crosslink in {region}")
+            print(f"less then 100 thresholded crosslink in {region}. Skipping {region}.")
             continue
         all_sites = pbt.BedTool.from_dataframe(df_xn_region[["chrom", "start", "end", "name", "score", "strand"]])
         # finds all crosslink sites that are not in peaks as reference for
@@ -1174,17 +1174,17 @@ def run(peak_file,
         for key, value in prtxn.items():
             prtxn_concat[key] = ", ".join([str(i) for i in value])
         df_prtxn = pd.DataFrame.from_dict(prtxn_concat, orient="index", columns=["prtxn"])
-        df_out = pd.merge(df_out, df_prtxn, left_index=True, right_index=True)
+        df_out = pd.merge(df_out, df_prtxn, left_index=True, right_index=True, how='outer')
         # calculate average relative occurences for each kmer around thresholded
         # crosslinks across relevant positions and add it to outfile table
         artxn = {x: np.mean([rtxn[x][y] for y in prtxn[x]]) for x in rtxn}
         df_artxn = pd.DataFrame.from_dict(artxn, orient="index", columns=["artxn"])
-        df_out = pd.merge(df_out, df_artxn, left_index=True, right_index=True)
+        df_out = pd.merge(df_out, df_artxn, left_index=True, right_index=True, how='outer')
         # calculate average relative occurences for each kmer around reference
         # crosslinks across relevant positions and add it to outfile table
         aroxn = {x: np.mean([roxn[x][y] for y in prtxn[x] if y in roxn[x].keys()]) for x in roxn}
         df_aroxn = pd.DataFrame.from_dict(aroxn, orient="index", columns=["aroxn"])
-        df_out = pd.merge(df_out, df_aroxn, left_index=True, right_index=True)
+        df_out = pd.merge(df_out, df_aroxn, left_index=True, right_index=True, how='outer')
         # calculate log2 of ratio between average relative occurences between
         # thresholded and reference crosslinks, this ratio, colaculated for each
         # kmer is called enrichement and is added to outfile table
@@ -1218,7 +1218,7 @@ def run(peak_file,
         # then added to outfile table
         # df_out["p-value"] = scipy.special.ndtr(-df_out["PEKA-score"])
         # kmer positional occurences around thresholded crosslinks on positions
-        # around -50 to 50 are also added to outfile table which is then finnaly
+        # around -50 to 50 are also added to outfile table which is then finally
         # written to file
         # get order of z-scores to select top kmers to plot
         top_kmers = df_out.sort_values(by='PEKA-score', ascending=False).index.tolist()[:top_n]

--- a/peka.py
+++ b/peka.py
@@ -18,7 +18,6 @@ different:
 - ncRNA (all other genes),
 - intergenic,
 - whole gene
-For whole gene and other exons
 Proceed only with those regions where tXn>100. For all analyses, exclude
 chrM and those scaffolds not included in the genome annotations.
 For each kmer, first count occurences at each specific position relative to
@@ -116,7 +115,7 @@ def cli():
     required.add_argument('-r',"--regions", type=str, required=True,
                         help='genome segmentation file produced as output of "iCount segment" function')
 
-    optional.add_argument('-k',"--kmerlength", type=int, choices=[4,5,6,7], default=5, nargs='?',
+    optional.add_argument('-k',"--kmerlength", type=int, choices=[3,4,5,6,7], default=5, nargs='?',
                         help='kmer length [DEFAULT 5]')
     optional.add_argument('-o',"--outputpath", type=str, default=os.getcwd(), nargs='?',
                         help='output folder [DEFAULT current directory]')

--- a/peka.py
+++ b/peka.py
@@ -1220,9 +1220,6 @@ def run(peak_file,
                 if relaxThreshold > np.min(list(percentageZero.values())):
                     # Using relaxed threshold
                     prtxn_conf = relaxThreshold
-                elif P_kmer_at_pos > round(np.min(list(percentageZero.values())), 2):
-                    # Using strict threshold
-                    prtxn_conf = P_kmer_at_pos
                 else:
                     # Use all positions within a window for peka score calculation
                     print('All positions will be used to calculate PEKA-score.')

--- a/peka.py
+++ b/peka.py
@@ -603,11 +603,6 @@ def get_average_poscount(pos_c):
     return avg
 
 
-def get_top_n_kmers(kmer_count, num):
-    """Get a list of top_n most frequent kmers."""
-    return [item[0] for item in sorted(kmer_count.items(), key=lambda x: x[1], reverse=True)[:num]]
-
-
 @ignore_warnings(category=ConvergenceWarning)
 def get_clustering(kmer_pos_count, x1, x2, kmer_length, window, smoot):
     """Smoothen positional data for each kmer and then cluster kmers.
@@ -1226,8 +1221,7 @@ def run(peak_file,
         # around -50 to 50 are also added to outfile table which is then finnaly
         # written to file
         # get order of z-scores to select top kmers to plot
-        kmers_order_of_enrichment = get_top_n_kmers(z_score, 4 ** kmer_length)
-        top_kmers = kmers_order_of_enrichment[:top_n]
+        top_kmers = df_out.sort_values(by='PEKA-score', ascending=False).index.tolist()[:top_n]
         # normalize kmer occurences by number of thresholded crosslinks for
         # easier comparison across different samples
         kmer_occ_per_txl = {x: {} for x in kmer_pos_count}

--- a/peka.py
+++ b/peka.py
@@ -1319,7 +1319,8 @@ def run(peak_file,
         df_out = pd.merge(df_out, df_z_score, left_index=True, right_index=True, how="outer")
         # using z-score we can also calculate p-values for each motif which are
         # then added to outfile table
-        df_out["p-value"] = scipy.special.ndtr(-df_out["PEKA-score"])
+        zscoresFromPEKAscore = scipy.stats.zscore(df_out['PEKA-score'], axis=0, ddof=0, nan_policy='omit')
+        df_out["p-value"] = scipy.special.ndtr(-zscoresFromPEKAscore)
         # kmer positional occurences around thresholded crosslinks on positions
         # around -50 to 50 are also added to outfile table which is then finally
         # written to file


### PR DESCRIPTION
1. Relevant positions
- improved way of determining the relevant positions, based on the number of crosslinks in a particular region and k-mer length.
- more control over position threshold is available to user, so if desired you can set a custom threshold value for relevant positions.

2. Important bugfixes for working with "masked" or "repeats_only" option.

3.  Added p-value calculation by getting zscores from PEKA-score distribution, assuming normal distribution of z-scores.
4. Changed how zeroDivisionError is handled - divided by minimum nonzero value for background, instead of an arbitrary value 0.05 as before.
5. Formatting, editing of descriptions